### PR TITLE
Fix MAC solver domain handling

### DIFF
--- a/src/cp/HeuristicMACSolver.java
+++ b/src/cp/HeuristicMACSolver.java
@@ -85,8 +85,14 @@ public class HeuristicMACSolver extends AbstractSolver {
                     
                     newListVariables.remove(var);
 
+                    // Créer une copie des domaines pour l'appel récursif
+                    Map<Variable, Set<Object>> newDomains = new HashMap<>();
+                    for (Map.Entry<Variable, Set<Object>> entry : evoDomains.entrySet()) {
+                        newDomains.put(entry.getKey(), new HashSet<>(entry.getValue()));
+                    }
+
                     // Appeler récursive
-                    Map<Variable, Object> result = MAC(newInstanciation, newListVariables, evoDomains);
+                    Map<Variable, Object> result = MAC(newInstanciation, newListVariables, newDomains);
 
                     if (result != null) {
                         return result;

--- a/src/cp/MACSolver.java
+++ b/src/cp/MACSolver.java
@@ -63,8 +63,12 @@ public class MACSolver extends AbstractSolver {
             Map<Variable, Object> newInstantiation = new HashMap<>(partialInstantiation);
             newInstantiation.put(var, value);
             if (isConsistent(newInstantiation)) {
-                
-                Map<Variable, Object> result = solverecMac(newInstantiation, listVariables, evoDomain);
+                Map<Variable, Set<Object>> newDomains = new HashMap<>();
+                for (Map.Entry<Variable, Set<Object>> entry : evoDomain.entrySet()) {
+                    newDomains.put(entry.getKey(), new HashSet<>(entry.getValue()));
+                }
+
+                Map<Variable, Object> result = solverecMac(newInstantiation, listVariables, newDomains);
 
                 if (result != null) {
                     return result;


### PR DESCRIPTION
## Summary
- fix MAC solver to copy domains at each recursion step
- ensure heuristic variant copies domains as well

## Testing
- `javac -d build -cp lib/blocksworld.jar:lib/bwgenerator.jar $(find src -name '*.java')`

------
https://chatgpt.com/codex/tasks/task_e_6849dd3f4f2c832f9863a481a49e1437